### PR TITLE
Colin's updates to smag_vis.f90

### DIFF
--- a/source/diff/smag_vis.f90
+++ b/source/diff/smag_vis.f90
@@ -1,42 +1,48 @@
 SUBROUTINE smag_vis(istep)
-! GET DEARDORFF STABILITY CORRECTED LENGTH SCALES, POSSIBLE NEW VIS MODEL
+! Classic Smagorinsky LES model.
+! WARNING: assumes ivis0 == 0 (set in pars.f90).
 
   USE pars
   USE fields
   USE con_data
   USE con_stats
 
-  REAL :: d_grid(izs-1:ize+1)
-  REAL :: sij2(nnx,iys:iye,izs-1:ize+1)
+  REAL :: d_grid, sij2, wz, uzp, vzp, wzp,
+  INTEGER :: iz, i, j, izm1, izp1
 
-  DO iz=izs-1,ize+1
-    izm1   = iz - 1
+  DO iz = izs-1, ize+1
+    izm1 = iz - 1
     izp1 = iz + 1
-    weit   = dzw(iz)/(dzw(iz) + dzw(izp1))
-    weit1  = 1.0 - weit
-    d_grid(iz) = (ABS(dx*dy*dzw(iz)))**(1./3.)
-    DO j=iys,iye
-      DO i=1,nnx
-        !strain rate tensor terms squared. strain rate tens: sij= 1/2*(u_<i,j> + u_<j,i>) 
+    weit = dzw(iz)/(dzw(iz) + dzw(izp1))
+    weit1 = 1.0 - weit
+    d_grid = dsl_z(iz) ! dsl_z gives correct SGS length scale given dealiased x and y derivatives
+
+    DO j = iys, iye
+      DO i = 1, nnx
+        ! Calculate vertical gradients.
+        wz  = (w(i,j,iz) - w(i,j,izm1))*dzw_i(iz)
+        uzp = (u(i,j,izp1) - u(i,j,iz))*dzu_i(izp1)
+        vzp = (v(i,j,izp1) - v(i,j,iz))*dzu_i(izp1)
+        wzp = (w(i,j,izp1) - w(i,j,iz))*dzw_i(izp1)
+
+        ! Strain rate tensor terms squared. strain rate tens: sij= 1/2*(u_<i,j> + u_<j,i>)
         s11 = weit1*ux(i,j,iz)**2 + weit*ux(i,j,izp1)**2
         s22 = weit1*vy(i,j,iz)**2 + weit*vy(i,j,izp1)**2
-        wz  = (w(ix,iy,iz)-w(ix,iy,izm1))*dzw_i(iz)
-        wzp = (w(ix,iy,izp1)-w(ix,iy,iz))*dzw_i(izp1)
-        s33 = (weit*wzp + weit1*wz)**2
-        s12 = weit1*(uy(ix,iy,iz) + vx(ix,iy,iz))**2 + weit*(uy(ix,iy,izp1) &
-              + vx(ix,iy,izp1))**2
-        uzmn=(u(ix,iy,izp1)-u(ix,iy,iz))*dzu_i(izp1)
-        vzmn=(v(ix,iy,izp1)-v(ix,iy,iz))*dzu_i(izp1)
-        s13 = (uzmn + wx(ix,iy,iz))**2
-        s23 = (vzmn + wy(ix,iy,iz))**2
-        !s12 =  (0.5 * (weit1*(uy(i,j,iz) + vx(i,j,iz)) + weit*(uy(i,j,izp1) + vx(i,j,izp1))))**2
-        !s13 =  (0.5 * ((((u(i,j,izp1) - u(i,j,iz)) * dzu_i(izp1) + wx(i,j,iz)))))**2
-        !s23 =  (0.5 * ((v(i,j,izp1) - v(i,j,iz)) * dzu_i(izp1) + wy(i,j,iz)))**2
-        sij2(i,j,iz) = 2.0*(s11 + s22 + s33) + s13 + s23 + s12!s11 + s22 + s33 + 2.0 * s12 + 2.0 * s13 + 2.0 * s23
-        vis_m(i,j,iz)  = (csmag)**2 * (d_grid(iz))**2 * SQRT(2.0 * sij2(i, j, iz))
-        vis_s(i,j,iz)  = vis_m(i,j,iz)
+        s33 = weit*wzp**2 + weit1*wz**2
+        s12 = weit1*(0.5*(uy(i,j,iz) + vx(i,j,iz)))**2 &
+              + weit*(0.5*(uy(i,j,izp1) + vx(i,j,izp1)))**2
+
+        ! Note from Colin: why s13 and s23 are not interpolated between iz and izp1
+        !   seems to be related to differing cell center/face alignments in RHS_UVW.
+        !   Either way, let's make sure we match TKE_VIS here (less the xy-means).
+        s13 = (0.5*(uzp + wx(i,j,iz)))**2
+        s23 = (0.5*(vzp + wy(i,j,iz)))**2
+
+        sij2 = s11 + s22 + s33 + 2.0*(s12 + s13 + s23)
+        vis_m(i,j,iz)  = (csmag * d_grid)**2 * SQRT(2.0 * sij2)
+        vis_s(i,j,iz)  = 3.0 * vis_m(i,j,iz) ! 1 + 2 * (alk/dslk) = 3 for non-stability-corrected length scales
         vis_sv(i,j,iz) = vis_s(i,j,iz)
-        r5(ix,iy,iz) = 0.0
+        r5(i,j,iz) = 0.0
       ENDDO
     ENDDO
   ENDDO


### PR DESCRIPTION
* Fixed DO iz limits to match TKE_VIS assuming ivis0 = 0 and nmatch = -1
* Fixed instances of (ix,iy,...) to read (i,j,...)
* Fixed consistency with weit and weit1 always being outside the squaring operator
* Kept preference for tracking 2's and 1/2's through the Sij calculations
* Added a factor of 3.0 to vis_s consistent with TKE_VIS, assuming alk/dslk = 1 (no stability-corrected length scale math)
* Removed array definitions for d_grid and sij2 as unnecessary
* Added explicit declarations of indexing variables and vertical gradients
* Changed d_grid calculation to the stored dsl_z
* Updated subroutine docstring