### PR TITLE
Updates for compiling and debugging on Derecho

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------------------
 # EDIT THESE
-COMPILER := gnu
+COMPILER := intel
 FC := mpif90
 SRCDIR := source
 BUILDDIR := build

--- a/make.cray
+++ b/make.cray
@@ -4,13 +4,12 @@ COMMON := -s default64 -f PIC -ef -J ./build
 FFLAGS := $(COMMON) -N 132
 F90FLAGS := $(COMMON)
 
-FFLAGS := -s default64 -f PIC -ef -J ./build
 LDFLAGS := # I don't think anything is necessary here
 
 # USE THESE FOR ACTUAL DEBUGGING
 SYNTAX := -dB -rl -R bcdsp -m2 # -dB = no binary, no optimization. -m2 output Errors, Warnings, and Cautions
 
-DBG1 := -O2 -G1
+DBG1 := -O1 -G1 -m4
 DBG2 := -O1 -G1 -Ktrap=fp -rl -R bcdsp -h fp1,scalar1,vector1,add_paren
 DBG3 := -O0 -G0 -Ktrap=fp -rl -R bcdsp -m2 -h add_paren # -O0 implies fp0, scalar0, vector0, etc.
 
@@ -19,11 +18,11 @@ DBG3 := -O0 -G0 -Ktrap=fp -rl -R bcdsp -m2 -h add_paren # -O0 implies fp0, scala
 #    Every way in which you can force Cray to do math slower is turned on
 OPT1 := -O0 -G0 -h add_paren # -O0 implies fp0, scalar0, vector0, etc.
 # -- "Normal" floating-point operations
-OPT2 := -O2 -G2
+OPT2 := -O2 -G2 -m4
 # -- Very optimized FLOPs, any way in which you can trade accuracy for speed is turned on.
 OPT3 := -O2 -G2 -h scalar3,vector3,fp4 # fma on at fp1 or higher
 
 # USE THESE FOR MAXIMUM COMPILER OPTIMIZATION
 # -- Once O3 and ipo are turned on, I don't think you can use -g anymore.
-OPT4 := -O3
+OPT4 := -O3 -m4
 OPT5 := -O3 -h aggress,scalar3,vector3,cache3,fp4

--- a/make.intel
+++ b/make.intel
@@ -1,7 +1,7 @@
 # MODIFY THESE AS YOU NEED/LIKE
 
 # add -xCORE-AVX512 for Frontera, -march=core-avx2 for Derecho
-COMMON := -real-size 64 -fpic -march=core-avx2 -module ./build -diag-disable=10448
+COMMON := -real-size 64 -fpic -module ./build -diag-disable=10448
 FFLAGS := $(COMMON) -extend-source 132
 F90FLAGS := $(COMMON)
 
@@ -10,9 +10,9 @@ LDFLAGS := -limf -lm # add any other needed files
 # USE THESE FOR ACTUAL DEBUGGING
 SYNTAX := -warn -syntax-only
 
-DBG1 := -g2 -debug all -traceback -O2  # O2 placed after g1 and debug, otherwise they override O2 to O0
-DBG2 := -g2 -debug all -traceback -fpe-all=0 -warn nounused -check all,noarg_temp_created -fp-model=strict  # -g2 == -g
-DBG3 := -g3 -debug all -traceback -prec-div -fprotect-parens -fpe-all=0 -warn nounused -check all -fp-model=strict,source
+DBG1 := -g2 -debug all -traceback -fpe-all=0 -O2  # O2 placed after g1 and debug, otherwise they override O2 to O0
+DBG2 := -g2 -debug all -traceback -fpe-all=0 -fp-model=strict -O0  # -g2 == -g
+DBG3 := -g3 -debug all -traceback -prec-div -fprotect-parens -fpe-all=0 -check all -fp-model=strict,source
 
 # USE THESE FOR CODE PROFILING
 # -- Very unoptimized floating-point operations.

--- a/runscript.sh
+++ b/runscript.sh
@@ -14,10 +14,10 @@ NOTEBOOK=${HOME}/LAB_NOTEBOOK/NCAR-LES
 
 ################################################################################
 ### EDIT AT WILL FOR EACH RUN
-compiler=cray          # options are [cray, intel, gnu]
-compile_mode=fast   # options useful on HPC are [debug, profile, fast]
-project=classic_smag    # creates sub-directory within NCAR-LES folders
-job_name=cray_test        # should be something unique at least for today
+compiler=intel       # options are [cray, intel, gnu]
+compile_mode=debug   # options useful on HPC are [debug, profile, fast]
+project=classic_smag # creates sub-directory within NCAR-LES folders
+job_name=${compiler}_${compile_mode}  # should be something unique at least for today
 RUN_DIR=${TOP_DIR}/${project}/${today}/${job_name}
 NOTES=${NOTEBOOK}/${project}/${today}/${job_name}
 outfile=logfile.out

--- a/source/init/init.f90
+++ b/source/init/init.f90
@@ -86,16 +86,12 @@ SUBROUTINE init
     sigma_p = pi2 * f_p
     grav_w = grav
 
-    ! RATIO OF K_1/K_P (PHILLIPS AND DONELAN)
-    r_kp = grav * (f2w * pi2 / u_10)**2
-    r_k1 = r_fac * grav / (cd_10 * u_10 * u_10)
-    rk_ratio = r_k1 / r_kp
-
     time = 0.0
 
     ! OUTERMOST COARSE GRID INDICES ARE BOUNDS OF GRID
     izlow = 1
     izup = nnz
+    write (*, *) zl, nnz
     dz = zl / nnz
     dzg = ABS(dz)
 

--- a/source/solve/rlim.f90
+++ b/source/solve/rlim.f90
@@ -1,7 +1,7 @@
 FUNCTION rlim(d1, d2, d3)
 ! CEE'S KAPPA = 1/3 SCHEME
-
-    r = (d1 - d2 + 1.e-100) / (d2 - d3 - 1.e-100)
+    r = sign(1e-15, d2 - d3) + (d2 - d3)
+    r = (d1 - d2) / r
     rlim = (d2 - d3) * AMAX1(0., AMIN1(r, AMIN1(1./6.+1./3.*r, 1.)))
 
     RETURN


### PR DESCRIPTION
* Makefile now defaults to the intel compiler suite (if debugging on laptop, now must specify COMPILER=gnu or use runscript with gnu chosen)
* make.cray compiler options updated after preliminary testing: Cray still not working on Derecho
* make.intel compiler options updated, Intel 2024 and Cray MPICH do work on Derecho
* rlim.f90 updated to avoid underflows and divide by zero
* init.f90 updated to remove useless lines of code that divide by zero
* Eventually runscript.sh should be removed from the repo tracker so that we're not pushing changes to the script to Githu Eventually runscript.sh should be removed from the repo tracker so that we're not pushing changes to the script to Github every time.b every time.